### PR TITLE
修复在 2020.1 报错的问题

### DIFF
--- a/src/com/github/setial/intellijjavadocs/action/JavaDocGenerateAction.java
+++ b/src/com/github/setial/intellijjavadocs/action/JavaDocGenerateAction.java
@@ -9,7 +9,7 @@ import com.github.setial.intellijjavadocs.operation.JavaDocWriter;
 import com.intellij.codeInsight.CodeInsightActionHandler;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataKeys;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.DumbService;
@@ -23,6 +23,7 @@ import com.intellij.psi.PsiMethod;
 import com.intellij.psi.javadoc.PsiDocComment;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.util.PsiUtilCore;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -39,7 +40,7 @@ public class JavaDocGenerateAction extends BaseAction {
 
     private static final Logger LOGGER = Logger.getInstance(JavaDocGenerateAction.class);
 
-    private JavaDocWriter writer;
+    private final JavaDocWriter writer;
 
     /**
      * Instantiates a new Java doc generate action.
@@ -55,7 +56,7 @@ public class JavaDocGenerateAction extends BaseAction {
      */
     public JavaDocGenerateAction(CodeInsightActionHandler handler) {
         super(handler);
-        writer = ServiceManager.getService(JavaDocWriter.class);
+        this.writer = ApplicationManager.getApplication().getComponent(JavaDocWriter.class);
     }
 
     /**
@@ -86,21 +87,21 @@ public class JavaDocGenerateAction extends BaseAction {
             return;
         }
         List<PsiElement> elements = new LinkedList<PsiElement>();
-        PsiElement firstElement = getJavaElement(PsiUtilCore.getElementAtOffset(file, startPosition));
+        PsiElement firstElement = this.getJavaElement(PsiUtilCore.getElementAtOffset(file, startPosition));
         if (firstElement != null) {
             PsiElement element = firstElement;
             do {
-                if (isAllowedElementType(element)) {
+                if (this.isAllowedElementType(element)) {
                     elements.add(element);
                 }
                 element = element.getNextSibling();
                 if (element == null) {
                     break;
                 }
-            } while (isElementInSelection(element, startPosition, endPosition));
+            } while (this.isElementInSelection(element, startPosition, endPosition));
         }
         for (PsiElement element : elements) {
-            processElement(element);
+            this.processElement(element);
         }
     }
 
@@ -110,13 +111,13 @@ public class JavaDocGenerateAction extends BaseAction {
      * @param element the Element
      */
     protected void processElement(@NotNull PsiElement element) {
-        JavaDocGenerator generator = getGenerator(element);
+        JavaDocGenerator generator = this.getGenerator(element);
         if (generator != null) {
             try {
                 @SuppressWarnings("unchecked")
                 PsiDocComment javaDoc = generator.generate(element);
                 if (javaDoc != null) {
-                    writer.write(javaDoc, element);
+                    this.writer.write(javaDoc, element);
                 }
             } catch (TemplateNotFoundException e) {
                 LOGGER.warn(e);

--- a/src/com/github/setial/intellijjavadocs/action/JavaDocRemoveAction.java
+++ b/src/com/github/setial/intellijjavadocs/action/JavaDocRemoveAction.java
@@ -2,8 +2,9 @@ package com.github.setial.intellijjavadocs.action;
 
 import com.github.setial.intellijjavadocs.operation.JavaDocWriter;
 import com.intellij.codeInsight.CodeInsightActionHandler;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.psi.PsiElement;
+
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -20,7 +21,7 @@ public class JavaDocRemoveAction extends JavaDocGenerateAction {
      */
     public JavaDocRemoveAction() {
         this(new JavaDocHandler());
-        writer = ServiceManager.getService(JavaDocWriter.class);
+        this.writer = ApplicationManager.getApplication().getComponent(JavaDocWriter.class);
     }
 
     /**
@@ -34,6 +35,6 @@ public class JavaDocRemoveAction extends JavaDocGenerateAction {
 
     @Override
     protected void processElement(@NotNull PsiElement element) {
-        writer.remove(element);
+        this.writer.remove(element);
     }
 }

--- a/src/com/github/setial/intellijjavadocs/action/JavaDocsRemoveAction.java
+++ b/src/com/github/setial/intellijjavadocs/action/JavaDocsRemoveAction.java
@@ -1,8 +1,9 @@
 package com.github.setial.intellijjavadocs.action;
 
 import com.github.setial.intellijjavadocs.operation.JavaDocWriter;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.psi.PsiElement;
+
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -12,17 +13,17 @@ import org.jetbrains.annotations.NotNull;
  */
 public class JavaDocsRemoveAction extends JavaDocsGenerateAction {
 
-    private JavaDocWriter writer;
+    private final JavaDocWriter writer;
 
     /**
      * Instantiates a new Java docs remove action.
      */
     public JavaDocsRemoveAction() {
-        writer = ServiceManager.getService(JavaDocWriter.class);
+        this.writer = ApplicationManager.getApplication().getComponent(JavaDocWriter.class);
     }
 
     @Override
     protected void processElement(@NotNull PsiElement element) {
-        writer.remove(element);
+        this.writer.remove(element);
     }
 }

--- a/src/com/github/setial/intellijjavadocs/configuration/impl/JavaDocConfigurationImpl.java
+++ b/src/com/github/setial/intellijjavadocs/configuration/impl/JavaDocConfigurationImpl.java
@@ -7,17 +7,19 @@ import com.github.setial.intellijjavadocs.model.settings.Level;
 import com.github.setial.intellijjavadocs.model.settings.Mode;
 import com.github.setial.intellijjavadocs.model.settings.Visibility;
 import com.github.setial.intellijjavadocs.template.DocTemplateManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.ui.Messages;
-import java.util.HashSet;
-import java.util.Set;
+
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * The type Java doc configuration impl.
@@ -34,14 +36,14 @@ public class JavaDocConfigurationImpl implements JavaDocConfiguration,
     private static final Logger LOGGER = Logger.getInstance(JavaDocConfigurationImpl.class);
 
     private JavaDocSettings settings;
-    private DocTemplateManager templateManager;
+    private final DocTemplateManager templateManager;
     private boolean loadedStoredConfig = false;
 
     /**
      * Instantiates a new Java doc configuration object.
      */
     public JavaDocConfigurationImpl() {
-        templateManager = ServiceManager.getService(DocTemplateManager.class);
+        this.templateManager = ApplicationManager.getApplication().getComponent(DocTemplateManager.class);
     }
 
     @NotNull
@@ -54,7 +56,7 @@ public class JavaDocConfigurationImpl implements JavaDocConfiguration,
     public JavaDocSettings getConfiguration() {
         JavaDocSettings result;
         try {
-            result = (JavaDocSettings)getSettings().clone();
+            result = (JavaDocSettings) this.getSettings().clone();
         } catch (Exception e) {
             // return null if cannot clone object
             result = null;
@@ -66,25 +68,25 @@ public class JavaDocConfigurationImpl implements JavaDocConfiguration,
     @Override
     public Element getState() {
         Element root = new Element("JAVA_DOC_SETTINGS_PLUGIN");
-        if (settings != null) {
-            settings.addToDom(root);
-            loadedStoredConfig = true;
+        if (this.settings != null) {
+            this.settings.addToDom(root);
+            this.loadedStoredConfig = true;
         }
         return root;
     }
 
     @Override
     public void loadState(@NotNull Element javaDocSettings) {
-        settings = new JavaDocSettings(javaDocSettings);
-        setupTemplates();
-        loadedStoredConfig = true;
+        this.settings = new JavaDocSettings(javaDocSettings);
+        this.setupTemplates();
+        this.loadedStoredConfig = true;
     }
 
     @Override
     public JavaDocSettings getSettings() {
-        if (!loadedStoredConfig) {
+        if (!this.loadedStoredConfig) {
             // setup default values
-            settings = new JavaDocSettings();
+            this.settings = new JavaDocSettings();
             Set<Level> levels = new HashSet<>();
             levels.add(Level.TYPE);
             levels.add(Level.METHOD);
@@ -95,27 +97,27 @@ public class JavaDocConfigurationImpl implements JavaDocConfiguration,
             visibilities.add(Visibility.PROTECTED);
             visibilities.add(Visibility.DEFAULT);
 
-            settings.getGeneralSettings().setOverriddenMethods(false);
-            settings.getGeneralSettings().setSplittedClassName(true);
-            settings.getGeneralSettings().setMode(Mode.UPDATE);
-            settings.getGeneralSettings().setLevels(levels);
-            settings.getGeneralSettings().setVisibilities(visibilities);
+            this.settings.getGeneralSettings().setOverriddenMethods(false);
+            this.settings.getGeneralSettings().setSplittedClassName(true);
+            this.settings.getGeneralSettings().setMode(Mode.UPDATE);
+            this.settings.getGeneralSettings().setLevels(levels);
+            this.settings.getGeneralSettings().setVisibilities(visibilities);
 
-            settings.getTemplateSettings().setClassTemplates(templateManager.getClassTemplates());
-            settings.getTemplateSettings().setConstructorTemplates(templateManager.getConstructorTemplates());
-            settings.getTemplateSettings().setMethodTemplates(templateManager.getMethodTemplates());
-            settings.getTemplateSettings().setFieldTemplates(templateManager.getFieldTemplates());
+            this.settings.getTemplateSettings().setClassTemplates(this.templateManager.getClassTemplates());
+            this.settings.getTemplateSettings().setConstructorTemplates(this.templateManager.getConstructorTemplates());
+            this.settings.getTemplateSettings().setMethodTemplates(this.templateManager.getMethodTemplates());
+            this.settings.getTemplateSettings().setFieldTemplates(this.templateManager.getFieldTemplates());
         }
-        return settings;
+        return this.settings;
     }
 
     @Override
     public void setupTemplates() {
         try {
-            templateManager.setClassTemplates(settings.getTemplateSettings().getClassTemplates());
-            templateManager.setConstructorTemplates(settings.getTemplateSettings().getConstructorTemplates());
-            templateManager.setMethodTemplates(settings.getTemplateSettings().getMethodTemplates());
-            templateManager.setFieldTemplates(settings.getTemplateSettings().getFieldTemplates());
+            this.templateManager.setClassTemplates(this.settings.getTemplateSettings().getClassTemplates());
+            this.templateManager.setConstructorTemplates(this.settings.getTemplateSettings().getConstructorTemplates());
+            this.templateManager.setMethodTemplates(this.settings.getTemplateSettings().getMethodTemplates());
+            this.templateManager.setFieldTemplates(this.settings.getTemplateSettings().getFieldTemplates());
         } catch (SetupTemplateException e) {
             LOGGER.error(e);
             Messages.showErrorDialog("Javadocs plugin is not available, cause: " + e.getMessage(), "Javadocs plugin");

--- a/src/com/github/setial/intellijjavadocs/operation/JavaDocWriter.java
+++ b/src/com/github/setial/intellijjavadocs/operation/JavaDocWriter.java
@@ -1,8 +1,9 @@
 package com.github.setial.intellijjavadocs.operation;
 
-import com.intellij.openapi.components.ApplicationComponent;
+import com.intellij.openapi.components.BaseComponent;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.javadoc.PsiDocComment;
+
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -10,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * @author Sergey Timofiychuk
  */
-public interface JavaDocWriter extends ApplicationComponent {
+public interface JavaDocWriter extends BaseComponent {
 
     /**
      * The constant WRITE_JAVADOC_COMMAND_NAME.

--- a/src/com/github/setial/intellijjavadocs/template/DocTemplateManager.java
+++ b/src/com/github/setial/intellijjavadocs/template/DocTemplateManager.java
@@ -1,10 +1,12 @@
 package com.github.setial.intellijjavadocs.template;
 
-import com.intellij.openapi.components.ApplicationComponent;
+import com.intellij.openapi.components.BaseComponent;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiMethod;
+
 import freemarker.template.Template;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -15,7 +17,7 @@ import java.util.Map;
  *
  * @author Sergey Timofiychuk
  */
-public interface DocTemplateManager extends ApplicationComponent {
+public interface DocTemplateManager extends BaseComponent {
 
     /**
      * The constant COMPONENT_NAME.

--- a/src/com/sgota/plugin/idea/javadocs2/settings/AppConfigurable.java
+++ b/src/com/sgota/plugin/idea/javadocs2/settings/AppConfigurable.java
@@ -2,9 +2,10 @@ package com.sgota.plugin.idea.javadocs2.settings;
 
 import com.github.setial.intellijjavadocs.configuration.JavaDocConfiguration;
 import com.github.setial.intellijjavadocs.ui.settings.ConfigPanel;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.options.Configurable;
-import javax.swing.*;
+
+import javax.swing.JComponent;
 
 /**
  * App configurable
@@ -30,34 +31,34 @@ public class AppConfigurable implements Configurable {
 
     @Override
     public JComponent createComponent() {
-        if (configPanel == null) {
-            JavaDocConfiguration service = ServiceManager.getService(JavaDocConfiguration.class);
-            configPanel = new ConfigPanel(service.getSettings());
+        if (this.configPanel == null) {
+            JavaDocConfiguration service = ApplicationManager.getApplication().getComponent(JavaDocConfiguration.class);
+            this.configPanel = new ConfigPanel(service.getSettings());
         }
-        reset();
-        return configPanel;
+        this.reset();
+        return this.configPanel;
     }
 
     @Override
     public boolean isModified() {
-        return configPanel.isModified();
+        return this.configPanel.isModified();
     }
 
     @Override
     public void apply() {
-        JavaDocConfiguration service = ServiceManager.getService(JavaDocConfiguration.class);
-        configPanel.apply();
+        JavaDocConfiguration service = ApplicationManager.getApplication().getComponent(JavaDocConfiguration.class);
+        this.configPanel.apply();
         service.setupTemplates();
     }
 
     @Override
     public void reset() {
-        configPanel.reset();
+        this.configPanel.reset();
     }
 
     @Override
     public void disposeUIResources() {
-        configPanel.disposeUIResources();
-        configPanel = null;
+        this.configPanel.disposeUIResources();
+        this.configPanel = null;
     }
 }


### PR DESCRIPTION
修复在 2020.1 报错的问题:
使用 ApplicationManager.getApplication().getComponent() 代替 ServiceManager.getService(), 用于解决在 IDEA 2020.1 报错的问题